### PR TITLE
Unix patch for resizing console window

### DIFF
--- a/DonutDecoded.ps1
+++ b/DonutDecoded.ps1
@@ -1,67 +1,68 @@
-
-
 $Ca = ".,-~:;=!*#$@"
 $sin = @(for ($i = 0; $i -lt 1000; $i += 1) { [Math]::Sin($i * 0.006283185307179) })
 $cos = @(for ($i = 0; $i -lt 1000; $i += 1) { [Math]::Cos($i * 0.006283185307179) })
 
+$isUnix = ([System.Environment]::OSVersion).Platform -like 'Unix'
+$hasResize = @(get-command resize).Count -gt 0
 
-[void][System.Console]::SetWindowSize(80, 44)
+if ($isUnix -and $hasResize) {
+	[void](resize -s 44 80)
+}else {
+	[void][System.Console]::SetWindowSize(80, 44)
+}
+
 Clear-Host
 while ($true) {
   
-  $oA = (' ' * 3520).ToCharArray()
-  $dA = [double[]]::new(3520)
+	$oA = (' ' * 3520).ToCharArray()
+	$dA = [double[]]::new(3520)
   
  
-  $tsA = $sin[($aA % 6.28*159.15)]  
-  $tcA = $cos[($aA % 6.28*159.15)]  
+	$tsA = $sin[($aA % 6.28 * 159.15)]  
+	$tcA = $cos[($aA % 6.28 * 159.15)]  
 
-  $tcB = $sin[($aA % 6.28*159.15)]  
-  $tsB = $cos[($aA % 6.28*159.15)]  
+	$tcB = $sin[($aA % 6.28 * 159.15)]  
+	$tsB = $cos[($aA % 6.28 * 159.15)]  
 
 
-  $aY = 0
-  while ($aY -lt 6.28) {
-    $tcY = $cos[($aY % 6.28*159.15)] 
-    $tsY = $sin[($aY % 6.28*159.15)] 
-    $tscYA = $tsY * $tcA
-    $Dp = $tcY + 2;
+	$aY = 0
+	while ($aY -lt 6.28) {
+		$tcY = $cos[($aY % 6.28 * 159.15)] 
+		$tsY = $sin[($aY % 6.28 * 159.15)] 
+		$tscYA = $tsY * $tcA
+		$Dp = $tcY + 2;
 
-    $aX = 0
-    while ($aX -lt 6.28) {
+		$aX = 0
+		while ($aX -lt 6.28) {
 
-      $tcX = $cos[($aX % 6.28*159.15)]
-      $tsX = $sin[($aX % 6.28*159.15)]
+			$tcX = $cos[($aX % 6.28 * 159.15)]
+			$tsX = $sin[($aX % 6.28 * 159.15)]
 
       
-      $tscXY = $tsX * $tcY
-      $iD = 1 / ($tsX * $Dp * $tsA + $tscYA + 5); 
+			$tscXY = $tsX * $tcY
+			$iD = 1 / ($tsX * $Dp * $tsA + $tscYA + 5); 
 
        
-      $tp = ($tsX * $Dp * $tcA - $tsY * $tsA); 
+			$tp = ($tsX * $Dp * $tcA - $tsY * $tsA); 
 
-      $sX = [int](40 + 40 * $iD * ($tcX * $Dp * $tcB - $tp * $tsB)); 
-      $sY = [int](20 + 20 * $iD * ($tcX * $Dp * $tsB + $tp * $tcB));
+			$sX = [int](40 + 40 * $iD * ($tcX * $Dp * $tcB - $tp * $tsB)); 
+			$sY = [int](20 + 20 * $iD * ($tcX * $Dp * $tsB + $tp * $tcB));
       
-      $Ix = (8 * (($tsY * $tsA - $tscXY * $tcA) * $tcB - $tscXY * $tsA - $tscYA - $tcX * $tcY * $tsB))
+			$Ix = (8 * (($tsY * $tsA - $tscXY * $tcA) * $tcB - $tscXY * $tsA - $tscYA - $tcX * $tcY * $tsB))
 
-      $idx = $sX + 80 * $sY
+			$idx = $sX + 80 * $sY
   
-      if ($dA[$idx] -lt $iD) {
-        $dA[$idx] = $iD;
-        $oA[$idx] = $Ca[$Ix];
-      }
+			if ($dA[$idx] -lt $iD) {
+				$dA[$idx] = $iD;
+				$oA[$idx] = $Ca[$Ix];
+			}
       
-      $aX += 0.02
-    }
-    $aY += 0.07
-  }
-  $aA += 0.09
+			$aX += 0.02
+		}
+		$aY += 0.07
+	}
+	$aA += 0.09
 
-  [Console]::SetCursorPosition(0, 0)
-  [console]::write([string]::join("", $oA))
+	[Console]::SetCursorPosition(0, 0)
+	[console]::write([string]::join("", $oA))
 }
-
-
-
-

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Donut.c-Powershell
 Donut.c but powershell!
 - Powershell 5.0, Windows, Font: Consolas
+- Powershell 7.0, Unix, Font: Monospace, Depends: xterm
 
 ```
                      $Ca = ".,-~:;=!*#$@";$sin `


### PR DESCRIPTION
Depends on xterm which on Ubuntu can be installed with `sudo apt install xterm`

Added note to readme which points out the dependency for Unix.